### PR TITLE
Increased length of REDIRECT_FLAGS to 3

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -4,7 +4,7 @@ use std::os::unix::io::{RawFd, AsRawFd};
 use std::io;
 use std::sync::atomic::{Ordering, AtomicBool, ATOMIC_BOOL_INIT};
 
-static REDIRECT_FLAGS: [AtomicBool; 2] = [ATOMIC_BOOL_INIT, ATOMIC_BOOL_INIT];
+static REDIRECT_FLAGS: [AtomicBool; 3] = [ATOMIC_BOOL_INIT, ATOMIC_BOOL_INIT, ATOMIC_BOOL_INIT];
 
 pub struct RedirectError<F> {
     pub error: io::Error,


### PR DESCRIPTION
This was causing an error when trying to Hold::stderr()
because STDERR_FILENO is 2, and the REDIRECT_FLAGS list
was not long enough