### PR TITLE
Introduce Windows Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,8 @@ license = "MIT"
 libc = "0.2"
 tempfile = "3.0"
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "*", features = ["winbase", "wincon", "processenv", "handleapi", "namedpipeapi"] }
+
 [dev-dependencies]
 lazy_static = "1"

--- a/examples/windows.rs
+++ b/examples/windows.rs
@@ -1,0 +1,51 @@
+extern crate gag;
+
+#[cfg(windows)]
+fn main() {
+    /////////////////////////////////////////////////////////////
+    // Stdout gagging
+	println!("STDOUT GAGGING", );
+    println!("you will see this");
+    let gag = gag::windows::stdout().unwrap();
+    println!("but not this");
+    drop(gag);
+    println!("and this");
+    /////////////////////////////////////////////////////////////
+
+    /////////////////////////////////////////////////////////////
+    // Stderr gagging
+	println!("STDERR GAGGING", );
+    eprintln!("you will see this");
+    let gag = gag::windows::stderr().unwrap();
+    eprintln!("but not this");
+    drop(gag);
+    eprintln!("and this");
+    /////////////////////////////////////////////////////////////
+
+    /////////////////////////////////////////////////////////////
+    // Redirecting
+	println!("REDIRECTING", );
+    use std::io::{Read, Write};
+
+    std::thread::spawn(move || {
+        let mut gag = gag::windows::stdout().unwrap();
+        let mut stderr = std::io::stderr();
+        loop {
+            let mut buf = Vec::new();
+            gag.read_to_end(&mut buf).unwrap();
+            stderr.write_all(&buf).unwrap();
+        }
+    });
+
+    println!("This should be printed on stderr");
+    eprintln!("This will be printed on stderr as well");
+
+    // This will exit and close the spawned thread.
+    // In most cases you will want to setup a channel and send a break signal to the loop,
+    // and then join the thread back into it once you are finished.
+
+    /////////////////////////////////////////////////////////////
+}
+
+#[cfg(unix)]
+fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,15 +102,30 @@
 //! println!("second");
 //! drop(hold); // printing happens here!
 //! ```
+#[cfg(unix)]
 extern crate libc;
+#[cfg(unix)]
 extern crate tempfile;
 
+#[cfg(unix)]
 mod buffer;
+#[cfg(unix)]
 mod gag;
+#[cfg(unix)]
 mod hold;
+#[cfg(unix)]
 mod redirect;
 
+#[cfg(unix)]
 pub use buffer::{Buffer, BufferRedirect};
+#[cfg(unix)]
 pub use gag::Gag;
+#[cfg(unix)]
 pub use hold::Hold;
+#[cfg(unix)]
 pub use redirect::{Redirect, RedirectError};
+
+#[cfg(windows)]
+extern crate winapi;
+#[cfg(windows)]
+pub mod windows;

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -6,119 +6,119 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 static REDIRECT_FLAGS: [AtomicBool; 3] = [
-    AtomicBool::new(false),
-    AtomicBool::new(false),
-    AtomicBool::new(false),
+	AtomicBool::new(false),
+	AtomicBool::new(false),
+	AtomicBool::new(false),
 ];
 
 pub struct RedirectError<F> {
-    pub error: io::Error,
-    pub file: F,
+	pub error: io::Error,
+	pub file: F,
 }
 
 impl<F> From<RedirectError<F>> for io::Error {
-    fn from(err: RedirectError<F>) -> io::Error {
-        err.error
-    }
+	fn from(err: RedirectError<F>) -> io::Error {
+		err.error
+	}
 }
 
 impl<F: Any> ::std::error::Error for RedirectError<F> {
-    fn description(&self) -> &str {
-        self.error.description()
-    }
-    fn cause(&self) -> Option<&::std::error::Error> {
-        Some(&self.error)
-    }
+	fn description(&self) -> &str {
+		self.error.description()
+	}
+	fn cause(&self) -> Option<&::std::error::Error> {
+		Some(&self.error)
+	}
 }
 
 impl<F> ::std::fmt::Display for RedirectError<F> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-        self.error.fmt(fmt)
-    }
+	fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+		self.error.fmt(fmt)
+	}
 }
 
 impl<F> ::std::fmt::Debug for RedirectError<F> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-        self.error.fmt(fmt)
-    }
+	fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+		self.error.fmt(fmt)
+	}
 }
 
 /// Redirect stderr/stdout to a file.
 pub struct Redirect<F> {
-    #[allow(dead_code)]
-    fds: RedirectFds,
-    file: F,
+	#[allow(dead_code)]
+	fds: RedirectFds,
+	file: F,
 }
 
 // Separate struct so we can destruct the redirect and drop the file descriptors.
 struct RedirectFds {
-    std_fd: RawFd,
-    std_fd_dup: RawFd,
+	std_fd: RawFd,
+	std_fd_dup: RawFd,
 }
 
 impl RedirectFds {
-    fn make(std_fd: RawFd, file_fd: RawFd) -> io::Result<RedirectFds> {
-        let std_fd_dup = unsafe { libc::dup(std_fd) };
-        if std_fd_dup < 0 {
-            return Err(io::Error::last_os_error());
-        }
+	fn make(std_fd: RawFd, file_fd: RawFd) -> io::Result<RedirectFds> {
+		let std_fd_dup = unsafe { libc::dup(std_fd) };
+		if std_fd_dup < 0 {
+			return Err(io::Error::last_os_error());
+		}
 
-        // If this ends up panicing, something is seriously wrong. Regardless, we will only end up
-        // leaking a single file descriptor so it's not the end of the world.
-        if REDIRECT_FLAGS[std_fd as usize].fetch_or(true, Ordering::Relaxed) {
-            unsafe {
-                libc::close(std_fd_dup);
-            }
-            return Err(io::Error::new(
-                io::ErrorKind::AlreadyExists,
-                "Redirect already exists.",
-            ));
-        }
+		// If this ends up panicing, something is seriously wrong. Regardless, we will only end up
+		// leaking a single file descriptor so it's not the end of the world.
+		if REDIRECT_FLAGS[std_fd as usize].fetch_or(true, Ordering::Relaxed) {
+			unsafe {
+				libc::close(std_fd_dup);
+			}
+			return Err(io::Error::new(
+				io::ErrorKind::AlreadyExists,
+				"Redirect already exists.",
+			));
+		}
 
-        // Dropping this will close std_fd_dup
-        let fds = RedirectFds { std_fd, std_fd_dup };
+		// Dropping this will close std_fd_dup
+		let fds = RedirectFds { std_fd, std_fd_dup };
 
-        match unsafe { libc::dup2(file_fd, std_fd) } {
-            // Drop is still correct even if this doesn't succeed.
-            -1 => Err(io::Error::last_os_error()),
-            _ => Ok(fds),
-        }
-    }
+		match unsafe { libc::dup2(file_fd, std_fd) } {
+			// Drop is still correct even if this doesn't succeed.
+			-1 => Err(io::Error::last_os_error()),
+			_ => Ok(fds),
+		}
+	}
 }
 
 impl Drop for RedirectFds {
-    fn drop(&mut self) {
-        unsafe {
-            // Check for errors?
-            libc::dup2(self.std_fd_dup, self.std_fd);
-            libc::close(self.std_fd_dup);
-            REDIRECT_FLAGS[self.std_fd as usize].store(false, Ordering::Relaxed);
-        }
-    }
+	fn drop(&mut self) {
+		unsafe {
+			// Check for errors?
+			libc::dup2(self.std_fd_dup, self.std_fd);
+			libc::close(self.std_fd_dup);
+			REDIRECT_FLAGS[self.std_fd as usize].store(false, Ordering::Relaxed);
+		}
+	}
 }
 
 impl<F> Redirect<F>
 where
-    F: AsRawFd,
+	F: AsRawFd,
 {
-    fn make(std_fd: RawFd, file: F) -> Result<Self, RedirectError<F>> {
-        let fds = match RedirectFds::make(std_fd, file.as_raw_fd()) {
-            Ok(fds) => fds,
-            Err(error) => return Err(RedirectError { error, file }),
-        };
-        Ok(Redirect { fds, file })
-    }
-    /// Redirect stdout to `file`.
-    pub fn stdout(file: F) -> Result<Self, RedirectError<F>> {
-        Redirect::make(libc::STDOUT_FILENO, file)
-    }
-    /// Redirect stderr to `file`.
-    pub fn stderr(file: F) -> Result<Self, RedirectError<F>> {
-        Redirect::make(libc::STDERR_FILENO, file)
-    }
+	fn make(std_fd: RawFd, file: F) -> Result<Self, RedirectError<F>> {
+		let fds = match RedirectFds::make(std_fd, file.as_raw_fd()) {
+			Ok(fds) => fds,
+			Err(error) => return Err(RedirectError { error, file }),
+		};
+		Ok(Redirect { fds, file })
+	}
+	/// Redirect stdout to `file`.
+	pub fn stdout(file: F) -> Result<Self, RedirectError<F>> {
+		Redirect::make(libc::STDOUT_FILENO, file)
+	}
+	/// Redirect stderr to `file`.
+	pub fn stderr(file: F) -> Result<Self, RedirectError<F>> {
+		Redirect::make(libc::STDERR_FILENO, file)
+	}
 
-    /// Extract inner file object.
-    pub fn into_inner(self) -> F {
-        self.file
-    }
+	/// Extract inner file object.
+	pub fn into_inner(self) -> F {
+		self.file
+	}
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -6,119 +6,119 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 static REDIRECT_FLAGS: [AtomicBool; 3] = [
-	AtomicBool::new(false),
-	AtomicBool::new(false),
-	AtomicBool::new(false),
+    AtomicBool::new(false),
+    AtomicBool::new(false),
+    AtomicBool::new(false),
 ];
 
 pub struct RedirectError<F> {
-	pub error: io::Error,
-	pub file: F,
+    pub error: io::Error,
+    pub file: F,
 }
 
 impl<F> From<RedirectError<F>> for io::Error {
-	fn from(err: RedirectError<F>) -> io::Error {
-		err.error
-	}
+    fn from(err: RedirectError<F>) -> io::Error {
+        err.error
+    }
 }
 
 impl<F: Any> ::std::error::Error for RedirectError<F> {
-	fn description(&self) -> &str {
-		self.error.description()
-	}
-	fn cause(&self) -> Option<&::std::error::Error> {
-		Some(&self.error)
-	}
+    fn description(&self) -> &str {
+        self.error.description()
+    }
+    fn cause(&self) -> Option<&::std::error::Error> {
+        Some(&self.error)
+    }
 }
 
 impl<F> ::std::fmt::Display for RedirectError<F> {
-	fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-		self.error.fmt(fmt)
-	}
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+        self.error.fmt(fmt)
+    }
 }
 
 impl<F> ::std::fmt::Debug for RedirectError<F> {
-	fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-		self.error.fmt(fmt)
-	}
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+        self.error.fmt(fmt)
+    }
 }
 
 /// Redirect stderr/stdout to a file.
 pub struct Redirect<F> {
-	#[allow(dead_code)]
-	fds: RedirectFds,
-	file: F,
+    #[allow(dead_code)]
+    fds: RedirectFds,
+    file: F,
 }
 
 // Separate struct so we can destruct the redirect and drop the file descriptors.
 struct RedirectFds {
-	std_fd: RawFd,
-	std_fd_dup: RawFd,
+    std_fd: RawFd,
+    std_fd_dup: RawFd,
 }
 
 impl RedirectFds {
-	fn make(std_fd: RawFd, file_fd: RawFd) -> io::Result<RedirectFds> {
-		let std_fd_dup = unsafe { libc::dup(std_fd) };
-		if std_fd_dup < 0 {
-			return Err(io::Error::last_os_error());
-		}
+    fn make(std_fd: RawFd, file_fd: RawFd) -> io::Result<RedirectFds> {
+        let std_fd_dup = unsafe { libc::dup(std_fd) };
+        if std_fd_dup < 0 {
+            return Err(io::Error::last_os_error());
+        }
 
-		// If this ends up panicing, something is seriously wrong. Regardless, we will only end up
-		// leaking a single file descriptor so it's not the end of the world.
-		if REDIRECT_FLAGS[std_fd as usize].fetch_or(true, Ordering::Relaxed) {
-			unsafe {
-				libc::close(std_fd_dup);
-			}
-			return Err(io::Error::new(
-				io::ErrorKind::AlreadyExists,
-				"Redirect already exists.",
-			));
-		}
+        // If this ends up panicing, something is seriously wrong. Regardless, we will only end up
+        // leaking a single file descriptor so it's not the end of the world.
+        if REDIRECT_FLAGS[std_fd as usize].fetch_or(true, Ordering::Relaxed) {
+            unsafe {
+                libc::close(std_fd_dup);
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "Redirect already exists.",
+            ));
+        }
 
-		// Dropping this will close std_fd_dup
-		let fds = RedirectFds { std_fd, std_fd_dup };
+        // Dropping this will close std_fd_dup
+        let fds = RedirectFds { std_fd, std_fd_dup };
 
-		match unsafe { libc::dup2(file_fd, std_fd) } {
-			// Drop is still correct even if this doesn't succeed.
-			-1 => Err(io::Error::last_os_error()),
-			_ => Ok(fds),
-		}
-	}
+        match unsafe { libc::dup2(file_fd, std_fd) } {
+            // Drop is still correct even if this doesn't succeed.
+            -1 => Err(io::Error::last_os_error()),
+            _ => Ok(fds),
+        }
+    }
 }
 
 impl Drop for RedirectFds {
-	fn drop(&mut self) {
-		unsafe {
-			// Check for errors?
-			libc::dup2(self.std_fd_dup, self.std_fd);
-			libc::close(self.std_fd_dup);
-			REDIRECT_FLAGS[self.std_fd as usize].store(false, Ordering::Relaxed);
-		}
-	}
+    fn drop(&mut self) {
+        unsafe {
+            // Check for errors?
+            libc::dup2(self.std_fd_dup, self.std_fd);
+            libc::close(self.std_fd_dup);
+            REDIRECT_FLAGS[self.std_fd as usize].store(false, Ordering::Relaxed);
+        }
+    }
 }
 
 impl<F> Redirect<F>
 where
-	F: AsRawFd,
+    F: AsRawFd,
 {
-	fn make(std_fd: RawFd, file: F) -> Result<Self, RedirectError<F>> {
-		let fds = match RedirectFds::make(std_fd, file.as_raw_fd()) {
-			Ok(fds) => fds,
-			Err(error) => return Err(RedirectError { error, file }),
-		};
-		Ok(Redirect { fds, file })
-	}
-	/// Redirect stdout to `file`.
-	pub fn stdout(file: F) -> Result<Self, RedirectError<F>> {
-		Redirect::make(libc::STDOUT_FILENO, file)
-	}
-	/// Redirect stderr to `file`.
-	pub fn stderr(file: F) -> Result<Self, RedirectError<F>> {
-		Redirect::make(libc::STDERR_FILENO, file)
-	}
+    fn make(std_fd: RawFd, file: F) -> Result<Self, RedirectError<F>> {
+        let fds = match RedirectFds::make(std_fd, file.as_raw_fd()) {
+            Ok(fds) => fds,
+            Err(error) => return Err(RedirectError { error, file }),
+        };
+        Ok(Redirect { fds, file })
+    }
+    /// Redirect stdout to `file`.
+    pub fn stdout(file: F) -> Result<Self, RedirectError<F>> {
+        Redirect::make(libc::STDOUT_FILENO, file)
+    }
+    /// Redirect stderr to `file`.
+    pub fn stderr(file: F) -> Result<Self, RedirectError<F>> {
+        Redirect::make(libc::STDERR_FILENO, file)
+    }
 
-	/// Extract inner file object.
-	pub fn into_inner(self) -> F {
-		self.file
-	}
+    /// Extract inner file object.
+    pub fn into_inner(self) -> F {
+        self.file
+    }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -44,11 +44,6 @@ use winapi::um::{
     winnt::HANDLE,
 };
 
-/// Gag type -- stdout.
-pub struct Stdout;
-/// Gag type -- stderr.
-pub struct Stderr;
-
 /// Holds the gag.
 /// Once dropped will return output to the original device.
 pub struct Gag<Io> {
@@ -69,7 +64,7 @@ pub struct Gag<Io> {
 /// drop(gag);
 /// println!("and this");
 /// ```
-pub fn stdout() -> io::Result<Gag<Stdout>> {
+pub fn stdout() -> io::Result<Gag<io::Stdout>> {
     Gag::redirect(STD_OUTPUT_HANDLE)
 }
 
@@ -83,7 +78,7 @@ pub fn stdout() -> io::Result<Gag<Stdout>> {
 /// drop(gag);
 /// eprintln!("and this");
 /// ```
-pub fn stderr() -> io::Result<Gag<Stderr>> {
+pub fn stderr() -> io::Result<Gag<io::Stdout>> {
     Gag::redirect(STD_ERROR_HANDLE)
 }
 
@@ -128,8 +123,8 @@ impl<Io> Drop for Gag<Io> {
 impl<Io> io::Read for Gag<Io> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if !has_bytes(self.read_handle)? {
-			return Ok(0);
-		}
+            return Ok(0);
+        }
 
         let buf_len: DWORD = buf.len() as DWORD;
         let mut bytes_read: DWORD = 0;
@@ -199,7 +194,7 @@ fn has_bytes(handle: HANDLE) -> io::Result<bool> {
             NULL as LPDWORD,
         )
     };
-	
+
     if result == 0 {
         return Err(io::Error::last_os_error());
     }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,7 +1,9 @@
-//! # Windows gagging.
-//! ---
+//! Gagging on windows targets.
 //!
-//! See [`stdout()`](#Stdout) and [`stderr()`](#Stderr) functions for simple examples.
+//! The windows gagging api is independent of the `gag` module, and the ergonomics of gagging is different.
+//! The gagging functionality is much the same.
+//!
+//! See [`stdout()`](./fn.stdout.html) and [`stderr()`](./fn.stdout.html) functions for simple examples.
 //! The following example demonstrates how to redirect the output, redirecting stdout to stderr.
 //!
 //! # Example
@@ -33,10 +35,10 @@ use winapi;
 use winapi::ctypes::c_void;
 use winapi::shared::{minwindef::DWORD, ntdef::NULL};
 use winapi::um::{
-    handleapi::INVALID_HANDLE_VALUE,
-    minwinbase::{OVERLAPPED, SECURITY_ATTRIBUTES},
-    winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE},
-    winnt::HANDLE,
+	handleapi::INVALID_HANDLE_VALUE,
+	minwinbase::{OVERLAPPED, SECURITY_ATTRIBUTES},
+	winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE},
+	winnt::HANDLE,
 };
 
 /// Gag type -- stdout.
@@ -47,12 +49,12 @@ pub struct Stderr;
 /// Holds the gag.
 /// Once dropped will return output to the original device.
 pub struct Gag<Io> {
-    write_handle: HANDLE,
-    read_handle: HANDLE,
-    original_handle: HANDLE,
-    std_device: DWORD,
-    eof: bool,
-    mrker: std::marker::PhantomData<Io>,
+	write_handle: HANDLE,
+	read_handle: HANDLE,
+	original_handle: HANDLE,
+	std_device: DWORD,
+	eof: bool,
+	mrker: std::marker::PhantomData<Io>,
 }
 
 /// Gags the stdout stream.
@@ -66,7 +68,7 @@ pub struct Gag<Io> {
 /// println!("and this");
 /// ```
 pub fn stdout() -> io::Result<Gag<Stdout>> {
-    Gag::redirect(STD_OUTPUT_HANDLE)
+	Gag::redirect(STD_OUTPUT_HANDLE)
 }
 
 /// Gags the stderr stream.
@@ -80,106 +82,106 @@ pub fn stdout() -> io::Result<Gag<Stdout>> {
 /// eprintln!("and this");
 /// ```
 pub fn stderr() -> io::Result<Gag<Stderr>> {
-    Gag::redirect(STD_ERROR_HANDLE)
+	Gag::redirect(STD_ERROR_HANDLE)
 }
 
 impl<Io> Gag<Io> {
-    fn redirect(std_device: DWORD) -> io::Result<Self> {
-        let original_handle = get_std_handle(std_device)?;
+	fn redirect(std_device: DWORD) -> io::Result<Self> {
+		let original_handle = get_std_handle(std_device)?;
 
-        let (read_handle, write_handle) = create_pipe()?;
+		let (read_handle, write_handle) = create_pipe()?;
 
-        set_std_handle(std_device, write_handle)?;
+		set_std_handle(std_device, write_handle)?;
 
-        Ok(Gag {
-            write_handle,
-            read_handle,
-            original_handle,
-            std_device,
-            eof: false,
-            mrker: std::marker::PhantomData,
-        })
-    }
+		Ok(Gag {
+			write_handle,
+			read_handle,
+			original_handle,
+			std_device,
+			eof: false,
+			mrker: std::marker::PhantomData,
+		})
+	}
 }
 
 impl<Io> Drop for Gag<Io> {
-    fn drop(&mut self) {
-        // failures could potentially leak memory, but should be okay with as they are only HANDLE size.
-        unsafe {
-            // failure here could disrupt normal printing
-            winapi::um::processenv::SetStdHandle(self.std_device, self.original_handle);
-        }
-        unsafe {
-            winapi::um::handleapi::CloseHandle(self.read_handle);
-        }
-        unsafe {
-            winapi::um::handleapi::CloseHandle(self.write_handle);
-        }
-    }
+	fn drop(&mut self) {
+		// failures could potentially leak memory, but should be okay with as they are only HANDLE size.
+		unsafe {
+			// failure here could disrupt normal printing
+			winapi::um::processenv::SetStdHandle(self.std_device, self.original_handle);
+		}
+		unsafe {
+			winapi::um::handleapi::CloseHandle(self.read_handle);
+		}
+		unsafe {
+			winapi::um::handleapi::CloseHandle(self.write_handle);
+		}
+	}
 }
 
 impl<Io> io::Read for Gag<Io> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if self.eof {
-            self.eof = false;
-            return Ok(0); // eof
-        }
-        let buf_len: DWORD = buf.len() as DWORD;
-        let mut bytes_read: DWORD = 0;
+	fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+		if self.eof {
+			self.eof = false;
+			return Ok(0); // eof
+		}
+		let buf_len: DWORD = buf.len() as DWORD;
+		let mut bytes_read: DWORD = 0;
 
-        let read_result = unsafe {
-            winapi::um::fileapi::ReadFile(
-                self.read_handle,
-                buf.as_mut_ptr() as *mut c_void,
-                buf_len,
-                &mut bytes_read,
-                NULL as *mut OVERLAPPED,
-            )
-        };
+		let read_result = unsafe {
+			winapi::um::fileapi::ReadFile(
+				self.read_handle,
+				buf.as_mut_ptr() as *mut c_void,
+				buf_len,
+				&mut bytes_read,
+				NULL as *mut OVERLAPPED,
+			)
+		};
 
-        match read_result {
-            0 => Err(io::Error::last_os_error()),
-            _ => {
-                if bytes_read < buf_len {
-                    // read less than the buffer, for pipes this means EOF reached
-                    self.eof = true;
-                }
-                Ok(bytes_read as usize)
-            }
-        }
-    }
+		match read_result {
+			0 => Err(io::Error::last_os_error()),
+			_ => {
+				if bytes_read < buf_len {
+					// read less than the buffer, for pipes this means EOF reached
+					self.eof = true;
+				}
+				Ok(bytes_read as usize)
+			}
+		}
+	}
 }
 
 fn get_std_handle(device: DWORD) -> io::Result<HANDLE> {
-    match unsafe { winapi::um::processenv::GetStdHandle(device) } {
-        INVALID_HANDLE_VALUE => Err(io::Error::last_os_error()),
-        handle => Ok(handle),
-    }
+	match unsafe { winapi::um::processenv::GetStdHandle(device) } {
+		INVALID_HANDLE_VALUE => Err(io::Error::last_os_error()),
+		handle => Ok(handle),
+	}
 }
 
 fn set_std_handle(device: DWORD, handle: HANDLE) -> io::Result<()> {
-    match unsafe { winapi::um::processenv::SetStdHandle(device, handle) } {
-        0 => Err(io::Error::last_os_error()),
-        _ => Ok(()),
-    }
+	match unsafe { winapi::um::processenv::SetStdHandle(device, handle) } {
+		0 => Err(io::Error::last_os_error()),
+		_ => Ok(()),
+	}
 }
 
 /// Returns (read_handle, write_handle).
 fn create_pipe() -> io::Result<(HANDLE, HANDLE)> {
-    let mut read_handle: HANDLE = NULL;
-    let mut write_handle: HANDLE = NULL;
+	let mut read_handle: HANDLE = NULL;
+	let mut write_handle: HANDLE = NULL;
 
-    let create_pipe_result = unsafe {
-        winapi::um::namedpipeapi::CreatePipe(
-            &mut read_handle,
-            &mut write_handle,
-            NULL as *mut SECURITY_ATTRIBUTES,
-            0, // default buffer size
-        )
-    };
+	let create_pipe_result = unsafe {
+		winapi::um::namedpipeapi::CreatePipe(
+			&mut read_handle,
+			&mut write_handle,
+			NULL as *mut SECURITY_ATTRIBUTES,
+			0, // default buffer size
+		)
+	};
 
-    match create_pipe_result {
-        0 => Err(io::Error::last_os_error()),
-        _ => Ok((read_handle, write_handle)),
-    }
+	match create_pipe_result {
+		0 => Err(io::Error::last_os_error()),
+		_ => Ok((read_handle, write_handle)),
+	}
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -78,7 +78,7 @@ pub fn stdout() -> io::Result<Gag<io::Stdout>> {
 /// drop(gag);
 /// eprintln!("and this");
 /// ```
-pub fn stderr() -> io::Result<Gag<io::Stdout>> {
+pub fn stderr() -> io::Result<Gag<io::Stderr>> {
     Gag::redirect(STD_ERROR_HANDLE)
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -33,12 +33,15 @@
 use std::io;
 use winapi;
 use winapi::ctypes::c_void;
-use winapi::shared::{minwindef::DWORD, ntdef::NULL};
+use winapi::shared::{
+    minwindef::{DWORD, LPDWORD},
+    ntdef::NULL,
+};
 use winapi::um::{
-	handleapi::INVALID_HANDLE_VALUE,
-	minwinbase::{OVERLAPPED, SECURITY_ATTRIBUTES},
-	winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE},
-	winnt::HANDLE,
+    handleapi::INVALID_HANDLE_VALUE,
+    minwinbase::{OVERLAPPED, SECURITY_ATTRIBUTES},
+    winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE},
+    winnt::HANDLE,
 };
 
 /// Gag type -- stdout.
@@ -49,12 +52,11 @@ pub struct Stderr;
 /// Holds the gag.
 /// Once dropped will return output to the original device.
 pub struct Gag<Io> {
-	write_handle: HANDLE,
-	read_handle: HANDLE,
-	original_handle: HANDLE,
-	std_device: DWORD,
-	eof: bool,
-	mrker: std::marker::PhantomData<Io>,
+    write_handle: HANDLE,
+    read_handle: HANDLE,
+    original_handle: HANDLE,
+    std_device: DWORD,
+    mrker: std::marker::PhantomData<Io>,
 }
 
 /// Gags the stdout stream.
@@ -68,7 +70,7 @@ pub struct Gag<Io> {
 /// println!("and this");
 /// ```
 pub fn stdout() -> io::Result<Gag<Stdout>> {
-	Gag::redirect(STD_OUTPUT_HANDLE)
+    Gag::redirect(STD_OUTPUT_HANDLE)
 }
 
 /// Gags the stderr stream.
@@ -82,26 +84,25 @@ pub fn stdout() -> io::Result<Gag<Stdout>> {
 /// eprintln!("and this");
 /// ```
 pub fn stderr() -> io::Result<Gag<Stderr>> {
-	Gag::redirect(STD_ERROR_HANDLE)
+    Gag::redirect(STD_ERROR_HANDLE)
 }
 
 impl<Io> Gag<Io> {
-	fn redirect(std_device: DWORD) -> io::Result<Self> {
-		let original_handle = get_std_handle(std_device)?;
+    fn redirect(std_device: DWORD) -> io::Result<Self> {
+        let original_handle = get_std_handle(std_device)?;
 
-		let (read_handle, write_handle) = create_pipe()?;
+        let (read_handle, write_handle) = create_pipe()?;
 
-		set_std_handle(std_device, write_handle)?;
+        set_std_handle(std_device, write_handle)?;
 
-		Ok(Gag {
-			write_handle,
-			read_handle,
-			original_handle,
-			std_device,
-			eof: false,
-			mrker: std::marker::PhantomData,
-		})
-	}
+        Ok(Gag {
+            write_handle,
+            read_handle,
+            original_handle,
+            std_device,
+            mrker: std::marker::PhantomData,
+        })
+    }
 }
 
 /// We can say `Gag` is safe as the `HANDLE`s are meant to last until we close them (with `CloseHandle`).
@@ -109,83 +110,99 @@ impl<Io> Gag<Io> {
 unsafe impl<Io> Send for Gag<Io> {}
 
 impl<Io> Drop for Gag<Io> {
-	fn drop(&mut self) {
-		// failures could potentially leak memory, but should be okay with as they are only HANDLE size.
-		unsafe {
-			// failure here could disrupt normal printing
-			winapi::um::processenv::SetStdHandle(self.std_device, self.original_handle);
-		}
-		unsafe {
-			winapi::um::handleapi::CloseHandle(self.read_handle);
-		}
-		unsafe {
-			winapi::um::handleapi::CloseHandle(self.write_handle);
-		}
-	}
+    fn drop(&mut self) {
+        // failures could potentially leak memory, but should be okay with as they are only HANDLE size.
+        unsafe {
+            // failure here could disrupt normal printing
+            winapi::um::processenv::SetStdHandle(self.std_device, self.original_handle);
+        }
+        unsafe {
+            winapi::um::handleapi::CloseHandle(self.read_handle);
+        }
+        unsafe {
+            winapi::um::handleapi::CloseHandle(self.write_handle);
+        }
+    }
 }
 
 impl<Io> io::Read for Gag<Io> {
-	fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-		if self.eof {
-			self.eof = false;
-			return Ok(0); // eof
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if !has_bytes(self.read_handle)? {
+			return Ok(0);
 		}
-		let buf_len: DWORD = buf.len() as DWORD;
-		let mut bytes_read: DWORD = 0;
 
-		let read_result = unsafe {
-			winapi::um::fileapi::ReadFile(
-				self.read_handle,
-				buf.as_mut_ptr() as *mut c_void,
-				buf_len,
-				&mut bytes_read,
-				NULL as *mut OVERLAPPED,
-			)
-		};
+        let buf_len: DWORD = buf.len() as DWORD;
+        let mut bytes_read: DWORD = 0;
 
-		match read_result {
-			0 => Err(io::Error::last_os_error()),
-			_ => {
-				if bytes_read < buf_len {
-					// read less than the buffer, for pipes this means EOF reached
-					self.eof = true;
-				}
-				Ok(bytes_read as usize)
-			}
-		}
-	}
+        let read_result = unsafe {
+            winapi::um::fileapi::ReadFile(
+                self.read_handle,
+                buf.as_mut_ptr() as *mut c_void,
+                buf_len,
+                &mut bytes_read,
+                NULL as *mut OVERLAPPED,
+            )
+        };
+
+        match read_result {
+            0 => Err(io::Error::last_os_error()),
+            _ => Ok(bytes_read as usize),
+        }
+    }
 }
 
 fn get_std_handle(device: DWORD) -> io::Result<HANDLE> {
-	match unsafe { winapi::um::processenv::GetStdHandle(device) } {
-		INVALID_HANDLE_VALUE => Err(io::Error::last_os_error()),
-		handle => Ok(handle),
-	}
+    match unsafe { winapi::um::processenv::GetStdHandle(device) } {
+        INVALID_HANDLE_VALUE => Err(io::Error::last_os_error()),
+        handle => Ok(handle),
+    }
 }
 
 fn set_std_handle(device: DWORD, handle: HANDLE) -> io::Result<()> {
-	match unsafe { winapi::um::processenv::SetStdHandle(device, handle) } {
-		0 => Err(io::Error::last_os_error()),
-		_ => Ok(()),
-	}
+    match unsafe { winapi::um::processenv::SetStdHandle(device, handle) } {
+        0 => Err(io::Error::last_os_error()),
+        _ => Ok(()),
+    }
 }
 
 /// Returns (read_handle, write_handle).
 fn create_pipe() -> io::Result<(HANDLE, HANDLE)> {
-	let mut read_handle: HANDLE = NULL;
-	let mut write_handle: HANDLE = NULL;
+    let mut read_handle: HANDLE = NULL;
+    let mut write_handle: HANDLE = NULL;
 
-	let create_pipe_result = unsafe {
-		winapi::um::namedpipeapi::CreatePipe(
-			&mut read_handle,
-			&mut write_handle,
-			NULL as *mut SECURITY_ATTRIBUTES,
-			0, // default buffer size
-		)
-	};
+    let create_pipe_result = unsafe {
+        winapi::um::namedpipeapi::CreatePipe(
+            &mut read_handle,
+            &mut write_handle,
+            NULL as *mut SECURITY_ATTRIBUTES,
+            0, // default buffer size
+        )
+    };
 
-	match create_pipe_result {
-		0 => Err(io::Error::last_os_error()),
-		_ => Ok((read_handle, write_handle)),
-	}
+    match create_pipe_result {
+        0 => Err(io::Error::last_os_error()),
+        _ => Ok((read_handle, write_handle)),
+    }
+}
+
+/// Uses PeekNamedPipe and checks TotalBytesAvail
+fn has_bytes(handle: HANDLE) -> io::Result<bool> {
+    let mut bytes_avail: DWORD = 0;
+
+    let result = unsafe {
+        winapi::um::namedpipeapi::PeekNamedPipe(
+            handle,
+            NULL as *mut c_void,
+            0,
+            NULL as LPDWORD,
+            &mut bytes_avail,
+            NULL as LPDWORD,
+        )
+    };
+	
+    if result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(bytes_avail > 0)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,30 @@
-//! Windows gagging.
+//! # Windows gagging.
+//! ---
+//!
+//! See [`stdout()`](#Stdout) and [`stderr()`](#Stderr) functions for simple examples.
+//! The following example demonstrates how to redirect the output, redirecting stdout to stderr.
+//!
+//! # Example
+//! ```rust,ignore
+//! use std::io::{Read, Write};
+//!
+//! std::thread::spawn(move || {
+//!		let mut gag = gag::windows::stdout().unwrap();
+//! 	let mut stderr = std::io::stderr();
+//! 	loop {
+//! 		let mut buf = Vec::new();
+//! 		gag.read_to_end(&mut buf).unwrap();
+//! 		stderr.write_all(&buf).unwrap();
+//! 	}
+//! });
+//!
+//! println!("This should be printed on stderr");
+//! eprintln!("This will be printed on stderr as well");
+//!
+//! // This will exit and close the spawned thread.
+//! // In most cases you will want to setup a channel and send a break signal to the loop,
+//! // and then join the thread back into it once you are finished.
+//! ```
 
 #![warn(missing_docs)]
 
@@ -7,10 +33,10 @@ use winapi;
 use winapi::ctypes::c_void;
 use winapi::shared::{minwindef::DWORD, ntdef::NULL};
 use winapi::um::{
-	handleapi::INVALID_HANDLE_VALUE,
-	minwinbase::{OVERLAPPED, SECURITY_ATTRIBUTES},
-	winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE},
-	winnt::HANDLE,
+    handleapi::INVALID_HANDLE_VALUE,
+    minwinbase::{OVERLAPPED, SECURITY_ATTRIBUTES},
+    winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE},
+    winnt::HANDLE,
 };
 
 /// Gag type -- stdout.
@@ -21,143 +47,139 @@ pub struct Stderr;
 /// Holds the gag.
 /// Once dropped will return output to the original device.
 pub struct Gag<Io> {
-	write_handle: HANDLE,
-	read_handle: HANDLE,
-	original_handle: HANDLE,
-	std_device: DWORD,
-	eof: bool,
-	mrker: std::marker::PhantomData<Io>,
+    write_handle: HANDLE,
+    read_handle: HANDLE,
+    original_handle: HANDLE,
+    std_device: DWORD,
+    eof: bool,
+    mrker: std::marker::PhantomData<Io>,
 }
 
-impl Gag<Stdout> {
-	/// Gags the stderr stream.
-	///
-	/// # Example
-	/// ```rust
-	/// println!("you will see this");
-	/// let gag = Gag::stdout().unwrap();
-	/// println!("but not this");
-	/// drop(gag);
-	/// println!("and this");
-	/// ```
-	pub fn stdout() -> io::Result<Self> {
-		Gag::redirect(STD_OUTPUT_HANDLE)
-	}
+/// Gags the stdout stream.
+///
+/// # Example
+/// ```rust,ignore
+/// println!("you will see this");
+/// let gag = gag::windows::stdout().unwrap();
+/// println!("but not this");
+/// drop(gag);
+/// println!("and this");
+/// ```
+pub fn stdout() -> io::Result<Gag<Stdout>> {
+    Gag::redirect(STD_OUTPUT_HANDLE)
 }
 
-impl Gag<Stdout> {
-	/// Gags the stderr stream.
-	///
-	/// # Example
-	/// ```rust
-	/// eprintln!("you will see this");
-	/// let gag = Gag::stderr().unwrap();
-	/// eprintln!("but not this");
-	/// drop(gag);
-	/// eprintln!("and this");
-	/// ```
-	pub fn stderr() -> io::Result<Self> {
-		Gag::redirect(STD_ERROR_HANDLE)
-	}
+/// Gags the stderr stream.
+///
+/// # Example
+/// ```rust,ignore
+/// eprintln!("you will see this");
+/// let gag = gag::windows::stderr().unwrap();
+/// eprintln!("but not this");
+/// drop(gag);
+/// eprintln!("and this");
+/// ```
+pub fn stderr() -> io::Result<Gag<Stderr>> {
+    Gag::redirect(STD_ERROR_HANDLE)
 }
 
 impl<Io> Gag<Io> {
-	fn redirect(std_device: DWORD) -> io::Result<Self> {
-		let original_handle = get_std_handle(std_device)?;
+    fn redirect(std_device: DWORD) -> io::Result<Self> {
+        let original_handle = get_std_handle(std_device)?;
 
-		let (read_handle, write_handle) = create_pipe()?;
+        let (read_handle, write_handle) = create_pipe()?;
 
-		set_std_handle(std_device, write_handle)?;
+        set_std_handle(std_device, write_handle)?;
 
-		Ok(Gag {
-			write_handle,
-			read_handle,
-			original_handle,
-			std_device,
-			eof: false,
-			mrker: std::marker::PhantomData,
-		})
-	}
+        Ok(Gag {
+            write_handle,
+            read_handle,
+            original_handle,
+            std_device,
+            eof: false,
+            mrker: std::marker::PhantomData,
+        })
+    }
 }
 
 impl<Io> Drop for Gag<Io> {
-	fn drop(&mut self) {
-		// failures could potentially leak memory, but should be okay with as they are only HANDLE size.
-		unsafe {
-			// failure here could disrupt normal printing
-			winapi::um::processenv::SetStdHandle(self.std_device, self.original_handle);
-		}
-		unsafe {
-			winapi::um::handleapi::CloseHandle(self.read_handle);
-		}
-		unsafe {
-			winapi::um::handleapi::CloseHandle(self.write_handle);
-		}
-	}
+    fn drop(&mut self) {
+        // failures could potentially leak memory, but should be okay with as they are only HANDLE size.
+        unsafe {
+            // failure here could disrupt normal printing
+            winapi::um::processenv::SetStdHandle(self.std_device, self.original_handle);
+        }
+        unsafe {
+            winapi::um::handleapi::CloseHandle(self.read_handle);
+        }
+        unsafe {
+            winapi::um::handleapi::CloseHandle(self.write_handle);
+        }
+    }
 }
 
 impl<Io> io::Read for Gag<Io> {
-	fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-		if self.eof {
-			self.eof = false;
-			return Ok(0); // eof
-		}
-		let buf_len: DWORD = buf.len() as DWORD;
-		let mut bytes_read: DWORD = 0;
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.eof {
+            self.eof = false;
+            return Ok(0); // eof
+        }
+        let buf_len: DWORD = buf.len() as DWORD;
+        let mut bytes_read: DWORD = 0;
 
-		let read_result = unsafe {
-			winapi::um::fileapi::ReadFile(
-				self.read_handle,
-				buf.as_mut_ptr() as *mut c_void,
-				buf_len,
-				&mut bytes_read,
-				NULL as *mut OVERLAPPED,
-			)
-		};
+        let read_result = unsafe {
+            winapi::um::fileapi::ReadFile(
+                self.read_handle,
+                buf.as_mut_ptr() as *mut c_void,
+                buf_len,
+                &mut bytes_read,
+                NULL as *mut OVERLAPPED,
+            )
+        };
 
-		match read_result {
-			0 => Err(io::Error::last_os_error()),
-			_ => {
-				if bytes_read < buf_len {
-					// read less than the buffer, for pipes this means EOF reached
-					self.eof = true;
-				}
-				Ok(bytes_read as usize)
-			}
-		}
-	}
+        match read_result {
+            0 => Err(io::Error::last_os_error()),
+            _ => {
+                if bytes_read < buf_len {
+                    // read less than the buffer, for pipes this means EOF reached
+                    self.eof = true;
+                }
+                Ok(bytes_read as usize)
+            }
+        }
+    }
 }
 
 fn get_std_handle(device: DWORD) -> io::Result<HANDLE> {
-	match unsafe { winapi::um::processenv::GetStdHandle(device) } {
-		INVALID_HANDLE_VALUE => Err(io::Error::last_os_error()),
-		handle => Ok(handle),
-	}
+    match unsafe { winapi::um::processenv::GetStdHandle(device) } {
+        INVALID_HANDLE_VALUE => Err(io::Error::last_os_error()),
+        handle => Ok(handle),
+    }
 }
 
 fn set_std_handle(device: DWORD, handle: HANDLE) -> io::Result<()> {
-	match unsafe { winapi::um::processenv::SetStdHandle(device, handle) } {
-		0 => Err(io::Error::last_os_error()),
-		_ => Ok(()),
-	}
+    match unsafe { winapi::um::processenv::SetStdHandle(device, handle) } {
+        0 => Err(io::Error::last_os_error()),
+        _ => Ok(()),
+    }
 }
 
 /// Returns (read_handle, write_handle).
 fn create_pipe() -> io::Result<(HANDLE, HANDLE)> {
-	let mut read_handle: HANDLE = NULL;
-	let mut write_handle: HANDLE = NULL;
+    let mut read_handle: HANDLE = NULL;
+    let mut write_handle: HANDLE = NULL;
 
-	let create_pipe_result = unsafe {
-		winapi::um::namedpipeapi::CreatePipe(
-			&mut read_handle,
-			&mut write_handle,
-			NULL as *mut SECURITY_ATTRIBUTES,
-			0, // default buffer size
-		)
-	};
+    let create_pipe_result = unsafe {
+        winapi::um::namedpipeapi::CreatePipe(
+            &mut read_handle,
+            &mut write_handle,
+            NULL as *mut SECURITY_ATTRIBUTES,
+            0, // default buffer size
+        )
+    };
 
-	match create_pipe_result {
-		0 => Err(io::Error::last_os_error()),
-		_ => Ok((read_handle, write_handle)),
-	}
+    match create_pipe_result {
+        0 => Err(io::Error::last_os_error()),
+        _ => Ok((read_handle, write_handle)),
+    }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,163 @@
+//! Windows gagging.
+
+#![warn(missing_docs)]
+
+use std::io;
+use winapi;
+use winapi::ctypes::c_void;
+use winapi::shared::{minwindef::DWORD, ntdef::NULL};
+use winapi::um::{
+	handleapi::INVALID_HANDLE_VALUE,
+	minwinbase::{OVERLAPPED, SECURITY_ATTRIBUTES},
+	winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE},
+	winnt::HANDLE,
+};
+
+/// Gag type -- stdout.
+pub struct Stdout;
+/// Gag type -- stderr.
+pub struct Stderr;
+
+/// Holds the gag.
+/// Once dropped will return output to the original device.
+pub struct Gag<Io> {
+	write_handle: HANDLE,
+	read_handle: HANDLE,
+	original_handle: HANDLE,
+	std_device: DWORD,
+	eof: bool,
+	mrker: std::marker::PhantomData<Io>,
+}
+
+impl Gag<Stdout> {
+	/// Gags the stderr stream.
+	///
+	/// # Example
+	/// ```rust
+	/// println!("you will see this");
+	/// let gag = Gag::stdout().unwrap();
+	/// println!("but not this");
+	/// drop(gag);
+	/// println!("and this");
+	/// ```
+	pub fn stdout() -> io::Result<Self> {
+		Gag::redirect(STD_OUTPUT_HANDLE)
+	}
+}
+
+impl Gag<Stdout> {
+	/// Gags the stderr stream.
+	///
+	/// # Example
+	/// ```rust
+	/// eprintln!("you will see this");
+	/// let gag = Gag::stderr().unwrap();
+	/// eprintln!("but not this");
+	/// drop(gag);
+	/// eprintln!("and this");
+	/// ```
+	pub fn stderr() -> io::Result<Self> {
+		Gag::redirect(STD_ERROR_HANDLE)
+	}
+}
+
+impl<Io> Gag<Io> {
+	fn redirect(std_device: DWORD) -> io::Result<Self> {
+		let original_handle = get_std_handle(std_device)?;
+
+		let (read_handle, write_handle) = create_pipe()?;
+
+		set_std_handle(std_device, write_handle)?;
+
+		Ok(Gag {
+			write_handle,
+			read_handle,
+			original_handle,
+			std_device,
+			eof: false,
+			mrker: std::marker::PhantomData,
+		})
+	}
+}
+
+impl<Io> Drop for Gag<Io> {
+	fn drop(&mut self) {
+		// failures could potentially leak memory, but should be okay with as they are only HANDLE size.
+		unsafe {
+			// failure here could disrupt normal printing
+			winapi::um::processenv::SetStdHandle(self.std_device, self.original_handle);
+		}
+		unsafe {
+			winapi::um::handleapi::CloseHandle(self.read_handle);
+		}
+		unsafe {
+			winapi::um::handleapi::CloseHandle(self.write_handle);
+		}
+	}
+}
+
+impl<Io> io::Read for Gag<Io> {
+	fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+		if self.eof {
+			self.eof = false;
+			return Ok(0); // eof
+		}
+		let buf_len: DWORD = buf.len() as DWORD;
+		let mut bytes_read: DWORD = 0;
+
+		let read_result = unsafe {
+			winapi::um::fileapi::ReadFile(
+				self.read_handle,
+				buf.as_mut_ptr() as *mut c_void,
+				buf_len,
+				&mut bytes_read,
+				NULL as *mut OVERLAPPED,
+			)
+		};
+
+		match read_result {
+			0 => Err(io::Error::last_os_error()),
+			_ => {
+				if bytes_read < buf_len {
+					// read less than the buffer, for pipes this means EOF reached
+					self.eof = true;
+				}
+				Ok(bytes_read as usize)
+			}
+		}
+	}
+}
+
+fn get_std_handle(device: DWORD) -> io::Result<HANDLE> {
+	match unsafe { winapi::um::processenv::GetStdHandle(device) } {
+		INVALID_HANDLE_VALUE => Err(io::Error::last_os_error()),
+		handle => Ok(handle),
+	}
+}
+
+fn set_std_handle(device: DWORD, handle: HANDLE) -> io::Result<()> {
+	match unsafe { winapi::um::processenv::SetStdHandle(device, handle) } {
+		0 => Err(io::Error::last_os_error()),
+		_ => Ok(()),
+	}
+}
+
+/// Returns (read_handle, write_handle).
+fn create_pipe() -> io::Result<(HANDLE, HANDLE)> {
+	let mut read_handle: HANDLE = NULL;
+	let mut write_handle: HANDLE = NULL;
+
+	let create_pipe_result = unsafe {
+		winapi::um::namedpipeapi::CreatePipe(
+			&mut read_handle,
+			&mut write_handle,
+			NULL as *mut SECURITY_ATTRIBUTES,
+			0, // default buffer size
+		)
+	};
+
+	match create_pipe_result {
+		0 => Err(io::Error::last_os_error()),
+		_ => Ok((read_handle, write_handle)),
+	}
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -104,6 +104,10 @@ impl<Io> Gag<Io> {
 	}
 }
 
+/// We can say `Gag` is safe as the `HANDLE`s are meant to last until we close them (with `CloseHandle`).
+/// As this is done on the `drop` of `Gag`, the handles should live for `Gag`s lifetime.
+unsafe impl<Io> Send for Gag<Io> {}
+
 impl<Io> Drop for Gag<Io> {
 	fn drop(&mut self) {
 		// failures could potentially leak memory, but should be okay with as they are only HANDLE size.

--- a/tests/test_redirect.rs
+++ b/tests/test_redirect.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 extern crate gag;
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
This crate is useful for a project I am working on but I needed support for windows. I have added windows support, albeit a very stripped down implementation. It would require users to use conditional compilation flags to use on both platforms as the api I implemented is quite simple.

I haven't matched the *nix api as the project I am working on requires asynchronous updating of the redirected outputs.